### PR TITLE
Add support for non-deterministic language, via variant property

### DIFF
--- a/src/actions/__tests__/workspaces.ts
+++ b/src/actions/__tests__/workspaces.ts
@@ -106,11 +106,13 @@ test('changeSideContentHeight generates correct action object', () => {
 
 test('chapterSelect generates correct action object', () => {
   const chapter = 3;
-  const action = chapterSelect(chapter, playgroundWorkspace);
+  const variant = 'default';
+  const action = chapterSelect(chapter, variant, playgroundWorkspace);
   expect(action).toEqual({
     type: actionTypes.CHAPTER_SELECT,
     payload: {
       chapter,
+      variant,
       workspaceLocation: playgroundWorkspace
     }
   });

--- a/src/actions/workspaces.ts
+++ b/src/actions/workspaces.ts
@@ -1,5 +1,6 @@
 import { action } from 'typesafe-actions';
 
+import { Variant } from 'js-slang/dist/types';
 import { ExternalLibraryName, Library } from '../components/assessment/assessmentShape';
 import { IPosition } from '../components/workspace/Editor';
 import { IWorkspaceState, SideContentType } from '../reducers/states';
@@ -46,9 +47,14 @@ export const changeExecTime = (execTime: string, workspaceLocation: WorkspaceLoc
 export const changeSideContentHeight = (height: number, workspaceLocation: WorkspaceLocation) =>
   action(actionTypes.CHANGE_SIDE_CONTENT_HEIGHT, { height, workspaceLocation });
 
-export const chapterSelect = (chapter: number, workspaceLocation: WorkspaceLocation) =>
+export const chapterSelect = (
+  chapter: number,
+  variant: Variant,
+  workspaceLocation: WorkspaceLocation
+) =>
   action(actionTypes.CHAPTER_SELECT, {
     chapter,
+    variant,
     workspaceLocation
   });
 

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -9,7 +9,7 @@ import Material from '../containers/material/MaterialContainer';
 import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import Sourcecast from '../containers/sourcecast/SourcecastContainer';
-import { Role, sourceChapters } from '../reducers/states';
+import { Role, sourceChapters, sourceURLNames } from '../reducers/states';
 import { stringParamToInt } from '../utils/paramParseHelpers';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
 import Contributors from './contributors';
@@ -112,7 +112,12 @@ const parsePrgrm = (props: RouteComponentProps<{}>) => {
 
 const parseChapter = (props: RouteComponentProps<{}>) => {
   const chapQuery = qs.parse(props.location.hash).chap;
-  const chap = chapQuery === undefined ? NaN : parseInt(chapQuery, 10);
+  const chap: number = sourceURLNames.has(chapQuery)
+    ? sourceURLNames.get(chapQuery)!
+    : chapQuery === undefined
+    ? NaN
+    : parseInt(chapQuery, 10);
+
   return sourceChapters.includes(chap) ? chap : undefined;
 };
 

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -9,7 +9,7 @@ import Material from '../containers/material/MaterialContainer';
 import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import Sourcecast from '../containers/sourcecast/SourcecastContainer';
-import { Role, sourceURLNames } from '../reducers/states';
+import { languageURLNames, Role } from '../reducers/states';
 import { stringParamToInt } from '../utils/paramParseHelpers';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
 import Contributors from './contributors';
@@ -121,8 +121,8 @@ const parsePrgrm = (props: RouteComponentProps<{}>) => {
 const parseChapter = (props: RouteComponentProps<{}>) => {
   const chapQuery = qs.parse(props.location.hash).chap;
 
-  const chap: number = sourceURLNames.has(chapQuery)
-    ? sourceURLNames.get(chapQuery)!.chapter
+  const chap: number = languageURLNames.has(chapQuery)
+    ? languageURLNames.get(chapQuery)!.chapter
     : chapQuery === undefined
     ? NaN
     : parseInt(chapQuery, 10);
@@ -133,8 +133,8 @@ const parseChapter = (props: RouteComponentProps<{}>) => {
 const parseVariant = (props: RouteComponentProps<{}>) => {
   const chapQuery = qs.parse(props.location.hash).chap;
 
-  const variant: Variant = sourceURLNames.has(chapQuery)
-    ? sourceURLNames.get(chapQuery)!.variant
+  const variant: Variant = languageURLNames.has(chapQuery)
+    ? languageURLNames.get(chapQuery)!.variant
     : 'default';
 
   return variant;

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -16,11 +16,14 @@ import Contributors from './contributors';
 import NavigationBar from './NavigationBar';
 import NotFound from './NotFound';
 
+import { Variant } from 'js-slang/dist/types';
+
 export interface IApplicationProps extends IDispatchProps, IStateProps, RouteComponentProps<{}> {}
 
 export interface IStateProps {
   accessToken?: string;
   currentPlaygroundChapter: number;
+  currentPlaygroundVariant: Variant;
   role?: Role;
   title: string;
   name?: string;
@@ -28,7 +31,11 @@ export interface IStateProps {
 }
 
 export interface IDispatchProps {
-  handleClearContext: (chapter: number, externalLibraryName: ExternalLibraryName) => void;
+  handleClearContext: (
+    chapter: number,
+    variant: Variant,
+    externalLibraryName: ExternalLibraryName
+  ) => void;
   handleEditorValueChange: (val: string) => void;
   handleEditorUpdateBreakpoints: (breakpoints: string[]) => void;
   handleEnsureLibrariesLoaded: () => void;
@@ -90,12 +97,13 @@ const toLogin = (props: IApplicationProps) => () => (
 const parsePlayground = (props: IApplicationProps) => {
   const prgrm = parsePrgrm(props);
   const chapter = parseChapter(props) || props.currentPlaygroundChapter;
+  const variant = parseVariant(props) || props.currentPlaygroundVariant;
   const externalLibraryName = parseExternalLibrary(props) || props.currentExternalLibrary;
   const execTime = parseExecTime(props);
   if (prgrm) {
     props.handleEditorValueChange(prgrm);
     props.handleEnsureLibrariesLoaded();
-    props.handleClearContext(chapter, externalLibraryName);
+    props.handleClearContext(chapter, variant, externalLibraryName);
     props.handleExternalLibrarySelect(externalLibraryName);
     props.handleSetExecTime(execTime);
   }
@@ -112,13 +120,24 @@ const parsePrgrm = (props: RouteComponentProps<{}>) => {
 
 const parseChapter = (props: RouteComponentProps<{}>) => {
   const chapQuery = qs.parse(props.location.hash).chap;
+
   const chap: number = sourceURLNames.has(chapQuery)
-    ? sourceURLNames.get(chapQuery)!
+    ? sourceURLNames.get(chapQuery)!.chapter
     : chapQuery === undefined
     ? NaN
     : parseInt(chapQuery, 10);
 
-  return chap;
+  return chap ? chap : undefined;
+};
+
+const parseVariant = (props: RouteComponentProps<{}>) => {
+  const chapQuery = qs.parse(props.location.hash).chap;
+
+  const variant: Variant = sourceURLNames.has(chapQuery)
+    ? sourceURLNames.get(chapQuery)!.variant
+    : 'default';
+
+  return variant;
 };
 
 const parseExternalLibrary = (props: RouteComponentProps<{}>) => {

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -9,7 +9,7 @@ import Material from '../containers/material/MaterialContainer';
 import MissionControlContainer from '../containers/missionControl';
 import Playground from '../containers/PlaygroundContainer';
 import Sourcecast from '../containers/sourcecast/SourcecastContainer';
-import { Role, sourceChapters, sourceURLNames } from '../reducers/states';
+import { Role, sourceURLNames } from '../reducers/states';
 import { stringParamToInt } from '../utils/paramParseHelpers';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
 import Contributors from './contributors';
@@ -118,7 +118,7 @@ const parseChapter = (props: RouteComponentProps<{}>) => {
     ? NaN
     : parseInt(chapQuery, 10);
 
-  return sourceChapters.includes(chap) ? chap : undefined;
+  return chap;
 };
 
 const parseExternalLibrary = (props: RouteComponentProps<{}>) => {

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { HotKeys } from 'react-hotkeys';
 import { RouteComponentProps } from 'react-router';
 
+import { Variant } from 'js-slang/dist/types';
 import { InterpreterOutput, SideContentType } from '../reducers/states';
 import { LINKS } from '../utils/constants';
 import { ExternalLibraryName, ExternalLibraryNames } from './assessment/assessmentShape';
@@ -70,6 +71,7 @@ export interface IStateProps {
   sharedbAceInitValue: string;
   sharedbAceIsInviting: boolean;
   sourceChapter: number;
+  sourceVariant: Variant;
   websocketStatus: number;
   externalLibraryName: string;
   usingSubst: boolean;
@@ -80,7 +82,7 @@ export interface IDispatchProps {
   handleBrowseHistoryDown: () => void;
   handleBrowseHistoryUp: () => void;
   handleChangeExecTime: (execTime: number) => void;
-  handleChapterSelect: (chapter: number) => void;
+  handleChapterSelect: (chapter: number, variant: Variant) => void;
   handleDeclarationNavigate: (cursorPosition: IPosition) => void;
   handleEditorEval: () => void;
   handleEditorHeightChange: (height: number) => void;
@@ -150,7 +152,10 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
       />
     );
 
-    const chapterSelectHandler = ({ chapter }: { chapter: number }, e: any) => {
+    const chapterSelectHandler = (
+      { chapter, variant }: { chapter: number; variant: Variant },
+      e: any
+    ) => {
       if (
         (chapter <= 2 && this.state.hasBreakpoints) ||
         this.state.selectedTab === SideContentType.substVisualizer
@@ -161,12 +166,13 @@ class Playground extends React.Component<IPlaygroundProps, PlaygroundState> {
         this.props.handleReplOutputClear();
         this.props.handleUsingSubst(false);
       }
-      this.props.handleChapterSelect(chapter);
+      this.props.handleChapterSelect(chapter, variant);
     };
     const chapterSelect = (
       <ChapterSelect
         handleChapterSelect={chapterSelectHandler}
         sourceChapter={this.props.sourceChapter}
+        sourceVariant={this.props.sourceVariant}
         key="chapter"
       />
     );

--- a/src/components/__tests__/Application.tsx
+++ b/src/components/__tests__/Application.tsx
@@ -5,14 +5,21 @@ import { mockRouterProps } from '../../mocks/components';
 import Application, { IApplicationProps } from '../Application';
 import { ExternalLibraryName, ExternalLibraryNames } from '../assessment/assessmentShape';
 
+import { Variant } from 'js-slang/dist/types';
+
 test('Application renders correctly', () => {
   const props: IApplicationProps = {
     ...mockRouterProps('/academy', {}),
     title: 'Cadet',
     currentPlaygroundChapter: 2,
+    currentPlaygroundVariant: 'default',
     handleLogOut: () => {},
     currentExternalLibrary: ExternalLibraryNames.NONE,
-    handleClearContext: (chapter: number, externalLibraryName: ExternalLibraryName) => {},
+    handleClearContext: (
+      chapter: number,
+      variant: Variant,
+      externalLibraryName: ExternalLibraryName
+    ) => {},
     handleEditorValueChange: (val: string) => {},
     handleEditorUpdateBreakpoints: (breakpoints: string[]) => {},
     handleEnsureLibrariesLoaded: () => {},

--- a/src/components/__tests__/Playground.tsx
+++ b/src/components/__tests__/Playground.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import { Variant } from 'js-slang/dist/types';
 import { SideContentType } from 'src/reducers/states';
 import { mockRouterProps } from '../../mocks/components';
 import { ExternalLibraryName, ExternalLibraryNames } from '../assessment/assessmentShape';
@@ -22,6 +23,7 @@ const baseProps = {
   sharedbAceIsInviting: false,
   sideContentHeight: 40,
   sourceChapter: 2,
+  sourceVariant: 'default' as Variant,
   externalLibraryName: ExternalLibraryNames.NONE,
   output: [],
   replValue: '',

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -1,4 +1,4 @@
-import { SourceError } from 'js-slang/dist/types';
+import { SourceError, Variant } from 'js-slang/dist/types';
 
 /*
  * Used to display information regarding an assessment in the UI.
@@ -166,6 +166,7 @@ type ExternalLibrary = {
 
 export type Library = {
   chapter: number;
+  variant?: Variant;
   external: ExternalLibrary;
   globals: Array<{
     0: string;

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -164,8 +164,6 @@ type ExternalLibrary = {
   symbols: string[];
 };
 
-export type Variant = 'lazy' | 'non-det' | 'default';
-
 export type Library = {
   chapter: number;
   variant?: Variant;

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -164,7 +164,7 @@ type ExternalLibrary = {
   symbols: string[];
 };
 
-export type Variant = 'lazy' | 'non-det' | 'default'
+export type Variant = 'lazy' | 'non-det' | 'default';
 
 export type Library = {
   chapter: number;

--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -164,6 +164,8 @@ type ExternalLibrary = {
   symbols: string[];
 };
 
+export type Variant = 'lazy' | 'non-det' | 'default'
+
 export type Library = {
   chapter: number;
   variant?: Variant;

--- a/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 import { externalLibraries } from '../../../reducers/externalLibraries';
-import { sourceLanguages, styliseChapter  } from '../../../reducers/states';
+import { sourceLanguages, styliseChapter } from '../../../reducers/states';
 
 import { ExternalLibraryName, IAssessment, Library } from '../../assessment/assessmentShape';
 import { controlButton } from '../../commons';
@@ -242,7 +242,11 @@ const altEval = (str: string): any => {
   return Function('"use strict";return (' + str + ')')();
 };
 
-const chapters = sourceLanguages.map(lang => ({ chapter: lang.chapter, variant: lang.variant, displayName: styliseChapter(lang.chapter, lang.variant) }));
+const chapters = sourceLanguages.map(lang => ({
+  chapter: lang.chapter,
+  variant: lang.variant,
+  displayName: styliseChapter(lang.chapter, lang.variant)
+}));
 
 const chapterSelect = (
   currentChap: number,

--- a/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 import { externalLibraries } from '../../../reducers/externalLibraries';
-import { sourceChapters, sourceDisplayNames } from '../../../reducers/states';
+import { sourceChapters, styliseChapter } from '../../../reducers/states';
 
 import { ExternalLibraryName, IAssessment, Library } from '../../assessment/assessmentShape';
 import { controlButton } from '../../commons';
@@ -239,10 +239,6 @@ const removeSpaces = (str: string) => {
 const altEval = (str: string): any => {
   return Function('"use strict";return (' + str + ')')();
 };
-
-function styliseChapter(chap: number) {
-  return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
-}
 
 const chapters = sourceChapters.map(chap => ({ displayName: styliseChapter(chap), chapter: chap }));
 

--- a/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -3,13 +3,15 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 import { externalLibraries } from '../../../reducers/externalLibraries';
-import { sourceChapters, styliseChapter } from '../../../reducers/states';
+import { sourceLanguages, styliseChapter  } from '../../../reducers/states';
 
 import { ExternalLibraryName, IAssessment, Library } from '../../assessment/assessmentShape';
 import { controlButton } from '../../commons';
 import { emptyLibrary } from '../assessmentTemplates';
 import { assignToPath, getValueFromPath } from './';
 import TextareaContent from './TextareaContent';
+
+import { Variant } from 'js-slang/dist/types';
 
 interface IProps {
   assessment: IAssessment;
@@ -120,7 +122,7 @@ export class DeploymentTab extends React.Component<IProps, {}> {
         <Divider />
         Interpreter:
         <br />
-        {chapterSelect(deployment.chapter, this.handleChapterSelect)}
+        {chapterSelect(deployment.chapter, deployment.variant, this.handleChapterSelect)}
         <Divider />
         {symbolsFragment}
         <Divider />
@@ -240,10 +242,11 @@ const altEval = (str: string): any => {
   return Function('"use strict";return (' + str + ')')();
 };
 
-const chapters = sourceChapters.map(chap => ({ displayName: styliseChapter(chap), chapter: chap }));
+const chapters = sourceLanguages.map(lang => ({ chapter: lang.chapter, variant: lang.variant, displayName: styliseChapter(lang.chapter, lang.variant) }));
 
 const chapterSelect = (
   currentChap: number,
+  variant?: Variant,
   handleSelect = (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => {}
 ) => (
   <ChapterSelectComponent
@@ -255,7 +258,7 @@ const chapterSelect = (
   >
     <Button
       className={Classes.MINIMAL}
-      text={styliseChapter(currentChap)}
+      text={styliseChapter(currentChap, variant)}
       rightIcon={IconNames.DOUBLE_CARET_VERTICAL}
     />
   </ChapterSelectComponent>

--- a/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 import { externalLibraries } from '../../../reducers/externalLibraries';
-import { sourceChapters } from '../../../reducers/states';
+import { sourceChapters, sourceDisplayNames } from '../../../reducers/states';
 
 import { ExternalLibraryName, IAssessment, Library } from '../../assessment/assessmentShape';
 import { controlButton } from '../../commons';
@@ -241,7 +241,7 @@ const altEval = (str: string): any => {
 };
 
 function styliseChapter(chap: number) {
-  return `Source \xa7${chap}`;
+  return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
 }
 
 const chapters = sourceChapters.map(chap => ({ displayName: styliseChapter(chap), chapter: chap }));

--- a/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/missionControl/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -250,7 +250,7 @@ const chapters = sourceLanguages.map(lang => ({
 
 const chapterSelect = (
   currentChap: number,
-  variant?: Variant,
+  variant: Variant = 'default',
   handleSelect = (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => {}
 ) => (
   <ChapterSelectComponent

--- a/src/components/sourcecast/Sourcecast.tsx
+++ b/src/components/sourcecast/Sourcecast.tsx
@@ -3,6 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import { Variant } from 'js-slang/dist/types';
 import { InterpreterOutput, SideContentType } from '../../reducers/states';
 import { ExternalLibraryName } from '../assessment/assessmentShape';
 import Workspace, { WorkspaceProps } from '../workspace';
@@ -57,6 +58,7 @@ export interface IStateProps {
   sideContentHeight?: number;
   sourcecastIndex: ISourcecastData[] | null;
   sourceChapter: number;
+  sourceVariant: Variant;
 }
 
 export interface IDispatchProps {
@@ -139,6 +141,7 @@ class Sourcecast extends React.Component<ISourcecastProps> {
       <ChapterSelect
         handleChapterSelect={chapterSelectHandler}
         sourceChapter={this.props.sourceChapter}
+        sourceVariant={this.props.sourceVariant}
         key="chapter"
       />
     );

--- a/src/components/sourcecast/Sourcereel.tsx
+++ b/src/components/sourcecast/Sourcereel.tsx
@@ -3,6 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import { Variant } from 'js-slang/dist/types';
 import { InterpreterOutput, SideContentType } from '../../reducers/states';
 import { ExternalLibraryName } from '../assessment/assessmentShape';
 import Workspace, { WorkspaceProps } from '../workspace';
@@ -52,6 +53,7 @@ export interface IStateProps {
   sideContentHeight?: number;
   sourcecastIndex: ISourcecastData[] | null;
   sourceChapter: number;
+  sourceVariant: Variant;
   timeResumed: number;
 }
 
@@ -142,6 +144,7 @@ class Sourcereel extends React.Component<ISourcereelProps> {
       <ChapterSelect
         handleChapterSelect={chapterSelectHandler}
         sourceChapter={this.props.sourceChapter}
+        sourceVariant={this.props.sourceVariant}
         key="chapter"
       />
     );

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -4,7 +4,7 @@ import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 
 import { Variant } from 'js-slang/dist/types';
-import { sourceChapters, sourceVariants, styliseChapter } from '../../../reducers/states';
+import { ISourceLanguage, sourceLanguages, styliseChapter } from '../../../reducers/states';
 
 export type ChapterSelectProps = {
   handleChapterSelect?: (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -20,22 +20,13 @@ export interface IChapter {
 }
 
 export function ChapterSelect(props: ChapterSelectProps) {
-  let chapters = sourceChapters.map(chap => {
-    const variant = 'default' as Variant;
+  const chapters = sourceLanguages.map((lang: ISourceLanguage) => {
     return {
-      displayName: styliseChapter(chap),
-      variant,
-      chapter: chap
+      chapter: lang.chapter,
+      variant: lang.variant,
+      displayName: styliseChapter(lang.chapter, lang.variant)
     };
   });
-
-  const chaptersWithVariants = sourceVariants.map((variant: Variant) => ({
-    displayName: styliseChapter(3) + ' ' + variant,
-    variant,
-    chapter: 3
-  }));
-
-  chapters = chapters.concat(chaptersWithVariants);
 
   const chapterRenderer: ItemRenderer<IChapter> = (chap, { handleClick }) => (
     <MenuItem

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 
-import { sourceChapters } from '../../../reducers/states';
+import { sourceChapters, sourceDisplayNames } from '../../../reducers/states';
 
 export type ChapterSelectProps = {
   handleChapterSelect?: (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -17,7 +17,10 @@ export interface IChapter {
 }
 
 export function ChapterSelect(props: ChapterSelectProps) {
-  const styliseChapter = (chap: number) => `Source \xa7${chap}`;
+  const styliseChapter = (chap: number) => {
+    return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
+  };
+
   const chapters = sourceChapters.map(chap => ({
     displayName: styliseChapter(chap),
     chapter: chap

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -28,12 +28,12 @@ export function ChapterSelect(props: ChapterSelectProps) {
     };
   });
 
-  const chapterRenderer: ItemRenderer<IChapter> = (chap, { handleClick }) => (
+  const chapterRenderer: ItemRenderer<IChapter> = (lang, { handleClick }) => (
     <MenuItem
       active={false}
-      key={chap.chapter + chap.variant}
+      key={lang.chapter + lang.variant}
       onClick={handleClick}
-      text={chap.displayName}
+      text={lang.displayName}
     />
   );
   const ChapterSelectComponent = Select.ofType<IChapter>();

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -52,7 +52,7 @@ export function ChapterSelect(props: ChapterSelectProps) {
     >
       <Button
         className={Classes.MINIMAL}
-        text={styliseChapter(currentChap)}
+        text={styliseChapter(currentChap, currentVariant)}
         rightIcon={IconNames.DOUBLE_CARET_VERTICAL}
       />
     </ChapterSelectComponent>

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -3,31 +3,53 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 
-import { sourceChapters, styliseChapter } from '../../../reducers/states';
+import { Variant } from 'js-slang/dist/types';
+import { sourceChapters, sourceVariants, styliseChapter } from '../../../reducers/states';
 
 export type ChapterSelectProps = {
   handleChapterSelect?: (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => void;
   sourceChapter: number;
+  sourceVariant: Variant;
   key: string;
 };
 
 export interface IChapter {
   chapter: number;
+  variant: Variant;
   displayName: string;
 }
 
 export function ChapterSelect(props: ChapterSelectProps) {
-  const chapters = sourceChapters.map(chap => ({
-    displayName: styliseChapter(chap),
-    chapter: chap
+  let chapters = sourceChapters.map(chap => {
+    const variant = 'default' as Variant;
+    return {
+      displayName: styliseChapter(chap),
+      variant,
+      chapter: chap
+    };
+  });
+
+  const chaptersWithVariants = sourceVariants.map((variant: Variant) => ({
+    displayName: styliseChapter(3) + ' ' + variant,
+    variant,
+    chapter: 3
   }));
+
+  chapters = chapters.concat(chaptersWithVariants);
+
   const chapterRenderer: ItemRenderer<IChapter> = (chap, { handleClick }) => (
-    <MenuItem active={false} key={chap.chapter} onClick={handleClick} text={chap.displayName} />
+    <MenuItem
+      active={false}
+      key={chap.chapter + chap.variant}
+      onClick={handleClick}
+      text={chap.displayName}
+    />
   );
   const ChapterSelectComponent = Select.ofType<IChapter>();
 
   const chapSelect = (
     currentChap: number,
+    currentVariant: Variant,
     handleSelect = (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => {}
   ) => (
     <ChapterSelectComponent
@@ -45,5 +67,5 @@ export function ChapterSelect(props: ChapterSelectProps) {
     </ChapterSelectComponent>
   );
 
-  return chapSelect(props.sourceChapter, props.handleChapterSelect);
+  return chapSelect(props.sourceChapter, props.sourceVariant, props.handleChapterSelect);
 }

--- a/src/components/workspace/controlBar/chapterSelect.tsx
+++ b/src/components/workspace/controlBar/chapterSelect.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 
-import { sourceChapters, sourceDisplayNames } from '../../../reducers/states';
+import { sourceChapters, styliseChapter } from '../../../reducers/states';
 
 export type ChapterSelectProps = {
   handleChapterSelect?: (i: IChapter, e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -17,10 +17,6 @@ export interface IChapter {
 }
 
 export function ChapterSelect(props: ChapterSelectProps) {
-  const styliseChapter = (chap: number) => {
-    return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
-  };
-
   const chapters = sourceChapters.map(chap => ({
     displayName: styliseChapter(chap),
     chapter: chap

--- a/src/containers/ApplicationContainer.ts
+++ b/src/containers/ApplicationContainer.ts
@@ -13,6 +13,8 @@ import { ExternalLibraryName } from '../components/assessment/assessmentShape';
 import { externalLibraries } from '../reducers/externalLibraries';
 import { IState } from '../reducers/states';
 
+import { Variant } from 'js-slang/dist/types';
+
 /**
  * Provides the title of the application for display.
  * An object with the relevant properties must be
@@ -26,6 +28,7 @@ const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   role: state.session.role,
   name: state.session.name,
   currentPlaygroundChapter: state.workspaces.playground.context.chapter,
+  currentPlaygroundVariant: state.workspaces.playground.context.variant,
   currentExternalLibrary: state.workspaces.playground.externalLibrary
 });
 
@@ -34,10 +37,15 @@ const workspaceLocation = WorkspaceLocations.playground;
 const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Dispatch<any>) =>
   bindActionCreators(
     {
-      handleClearContext: (chapter: number, externalLibraryName: ExternalLibraryName) =>
+      handleClearContext: (
+        chapter: number,
+        variant: Variant,
+        externalLibraryName: ExternalLibraryName
+      ) =>
         beginClearContext(
           {
             chapter,
+            variant,
             external: {
               name: externalLibraryName,
               symbols: externalLibraries.get(externalLibraryName)!

--- a/src/containers/PlaygroundContainer.ts
+++ b/src/containers/PlaygroundContainer.ts
@@ -2,6 +2,7 @@ import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
 
+import { Variant } from 'js-slang/dist/types';
 import {
   beginDebuggerPause,
   beginInterruptExecution,
@@ -58,6 +59,7 @@ const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   sharedbAceInitValue: state.workspaces.playground.sharedbAceInitValue,
   sideContentHeight: state.workspaces.playground.sideContentHeight,
   sourceChapter: state.workspaces.playground.context.chapter,
+  sourceVariant: state.workspaces.playground.context.variant,
   websocketStatus: state.workspaces.playground.websocketStatus,
   externalLibraryName: state.workspaces.playground.externalLibrary,
   usingSubst: state.playground.usingSubst
@@ -74,7 +76,8 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChangeExecTime: (execTime: number) =>
         changeExecTime(execTime.toString(), workspaceLocation),
-      handleChapterSelect: (chapter: number) => chapterSelect(chapter, workspaceLocation),
+      handleChapterSelect: (chapter: number, variant: Variant) =>
+        chapterSelect(chapter, variant, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),
       handleEditorEval: () => evalEditor(workspaceLocation),

--- a/src/containers/academy/grading/GradingWorkspaceContainer.ts
+++ b/src/containers/academy/grading/GradingWorkspaceContainer.ts
@@ -75,7 +75,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryDown: () => browseReplHistoryDown(workspaceLocation),
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChapterSelect: (chapter: any, changeEvent: any) =>
-        chapterSelect(chapter, workspaceLocation),
+        chapterSelect(chapter, 'default', workspaceLocation),
       handleClearContext: (library: Library) => beginClearContext(library, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),

--- a/src/containers/assessment/AssessmentWorkspaceContainer.ts
+++ b/src/containers/assessment/AssessmentWorkspaceContainer.ts
@@ -76,7 +76,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryDown: () => browseReplHistoryDown(workspaceLocation),
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChapterSelect: (chapter: any, changeEvent: any) =>
-        chapterSelect(chapter, workspaceLocation),
+        chapterSelect(chapter, 'default', workspaceLocation),
       handleClearContext: (library: Library) => beginClearContext(library, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),

--- a/src/containers/missionControl/EditingWorkspaceContainer.ts
+++ b/src/containers/missionControl/EditingWorkspaceContainer.ts
@@ -67,7 +67,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryDown: () => browseReplHistoryDown(workspaceLocation),
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChapterSelect: (chapter: any, changeEvent: any) =>
-        chapterSelect(chapter, workspaceLocation),
+        chapterSelect(chapter, 'default', workspaceLocation),
       handleClearContext: (library: Library) => beginClearContext(library, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),

--- a/src/containers/sourcecast/SourcecastContainer.ts
+++ b/src/containers/sourcecast/SourcecastContainer.ts
@@ -66,7 +66,8 @@ const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   replValue: state.workspaces.sourcecast.replValue,
   sideContentHeight: state.workspaces.sourcecast.sideContentHeight,
   sourcecastIndex: state.workspaces.sourcecast.sourcecastIndex,
-  sourceChapter: state.workspaces.sourcecast.context.chapter
+  sourceChapter: state.workspaces.sourcecast.context.chapter,
+  sourceVariant: state.workspaces.sourcecast.context.variant
 });
 
 const location: WorkspaceLocation = 'sourcecast';
@@ -77,7 +78,7 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
       handleActiveTabChange: (activeTab: SideContentType) => updateActiveTab(activeTab, location),
       handleBrowseHistoryDown: () => browseReplHistoryDown(location),
       handleBrowseHistoryUp: () => browseReplHistoryUp(location),
-      handleChapterSelect: (chapter: number) => chapterSelect(chapter, location),
+      handleChapterSelect: (chapter: number) => chapterSelect(chapter, 'default', location),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(location, cursorPosition),
       handleEditorEval: () => evalEditor(location),

--- a/src/containers/sourcecast/SourcereelContainer.ts
+++ b/src/containers/sourcecast/SourcereelContainer.ts
@@ -59,6 +59,7 @@ const mapStateToProps: MapStateToProps<IStateProps, {}, IState> = state => ({
   sideContentHeight: state.workspaces.sourcereel.sideContentHeight,
   sourcecastIndex: state.workspaces.sourcecast.sourcecastIndex,
   sourceChapter: state.workspaces.sourcereel.context.chapter,
+  sourceVariant: state.workspaces.sourcereel.context.variant,
   timeElapsedBeforePause: state.workspaces.sourcereel.timeElapsedBeforePause,
   timeResumed: state.workspaces.sourcereel.timeResumed
 });
@@ -71,7 +72,7 @@ const mapDispatchToProps: MapDispatchToProps<IDispatchProps, {}> = (dispatch: Di
       handleActiveTabChange: (activeTab: SideContentType) => updateActiveTab(activeTab, location),
       handleBrowseHistoryDown: () => browseReplHistoryDown(location),
       handleBrowseHistoryUp: () => browseReplHistoryUp(location),
-      handleChapterSelect: (chapter: number) => chapterSelect(chapter, location),
+      handleChapterSelect: (chapter: number) => chapterSelect(chapter, 'default', location),
       handleDeclarationNavigate: (cursorPosition: IPosition) =>
         navigateToDeclaration(location, cursorPosition),
       handleDeleteSourcecastEntry: (id: number) => deleteSourcecastEntry(id, 'sourcecast'),

--- a/src/reducers/__tests__/workspaces.ts
+++ b/src/reducers/__tests__/workspaces.ts
@@ -491,6 +491,7 @@ describe('END_CLEAR_CONTEXT', () => {
       const location = action.payload.workspaceLocation;
       const context = createContext<WorkspaceLocation>(
         library.chapter,
+        'default',
         library.external.symbols,
         location
       );

--- a/src/reducers/__tests__/workspaces.ts
+++ b/src/reducers/__tests__/workspaces.ts
@@ -493,7 +493,7 @@ describe('END_CLEAR_CONTEXT', () => {
         library.chapter,
         library.external.symbols,
         location,
-        'default',
+        'default'
       );
 
       expect(result).toEqual({

--- a/src/reducers/__tests__/workspaces.ts
+++ b/src/reducers/__tests__/workspaces.ts
@@ -491,9 +491,9 @@ describe('END_CLEAR_CONTEXT', () => {
       const location = action.payload.workspaceLocation;
       const context = createContext<WorkspaceLocation>(
         library.chapter,
-        'default',
         library.external.symbols,
-        location
+        location,
+        'default',
       );
 
       expect(result).toEqual({

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -237,6 +237,17 @@ export const languageURLNames: Map<string, ISourceLanguage> = new Map([
   ['3_Non_Det', { chapter: 3, variant: 'non-det' }]
 ]);
 
+export const urlName = (chapter: number, variant: Variant = 'default'): string => {
+  for (const name of languageURLNames.keys()) {
+    const language: ISourceLanguage = languageURLNames.get(name)!;
+    if (language.chapter === chapter && language.variant === variant) {
+      return name;
+    }
+  }
+
+  return chapter.toString();
+};
+
 export const styliseChapter = (chap: number, variant: Variant = 'default') => {
   let res = `Source \xa7${chap}`;
   if (variantDisplay.has(variant)) {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -219,12 +219,12 @@ export enum Role {
  * Defines what chapters are available for usage.
  * For external libraries, see externalLibraries.ts
  */
-export const sourceChapters = [1, 2, 3, 4, 4.3];
-export const sourceDisplayNames: Map<number, string> = new Map([[4.3, '3 Non-Det']]);
+export const sourceChapters = [1, 2, 3, 4];
+export const sourceVariants = ['non-det'];
 export const sourceURLNames: Map<string, number> = new Map([['3_Non_Det', 4.3]]);
 
 export const styliseChapter = (chap: number) => {
-  return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
+  return `Source \xa7${chap}`;
 };
 
 const currentEnvironment = (): ApplicationEnvironment => {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -232,16 +232,17 @@ export const sourceLanguages: ISourceLanguage[] = [
   { chapter: 4, variant: 'default' }
 ];
 
-const variantDisplay: Map<Variant, string> = new Map([
-  ['default', ''],
-  ['non-det', 'Non-Det']
+const variantDisplay: Map<Variant, string> = new Map([['default', ''], ['non-det', 'Non-Det']]);
+export const sourceURLNames: Map<string, ISourceLanguage> = new Map([
+  ['3_Non_Det', { chapter: 3, variant: 'non-det' }]
 ]);
-export const sourceURLNames: Map<string, number> = new Map([['3_Non_Det', 4.3]]);
 
 export const styliseChapter = (chap: number, variant?: Variant) => {
-  
-  return `Source \xa7${chap}` + 
-    (!variant || variantDisplay[variant] === '' ? '' : ' ' + variantDisplay[variant]);
+  let res = `Source \xa7${chap}`;
+  if (variant && variantDisplay.has(variant)) {
+    res += variantDisplay.get(variant);
+  }
+  return res;
 };
 
 const currentEnvironment = (): ApplicationEnvironment => {
@@ -283,7 +284,7 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): IW
     DEFAULT_SOURCE_CHAPTER,
     [],
     workspaceLocation,
-    DEFAULT_SOURCE_VARIANT,
+    DEFAULT_SOURCE_VARIANT
   ),
   editorPrepend: '',
   editorSessionId: '',

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -23,7 +23,7 @@ import {
   RecordingStatus
 } from '../components/sourcecast/sourcecastShape';
 import { IPosition } from '../components/workspace/Editor';
-import { DEFAULT_SOURCE_CHAPTER } from '../utils/constants';
+import { DEFAULT_SOURCE_CHAPTER, DEFAULT_SOURCE_VARIANT } from '../utils/constants';
 import { HistoryHelper } from '../utils/history';
 import { createContext } from '../utils/slangHelper';
 
@@ -256,7 +256,7 @@ export const defaultEditorValue = '// Type your program in here!';
 export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): IWorkspaceState => ({
   autogradingResults: [],
   breakpoints: [],
-  context: createContext<WorkspaceLocation>(DEFAULT_SOURCE_CHAPTER, [], workspaceLocation),
+  context: createContext<WorkspaceLocation>(DEFAULT_SOURCE_CHAPTER, DEFAULT_SOURCE_VARIANT, [], workspaceLocation),
   editorPrepend: '',
   editorSessionId: '',
   editorValue:

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -233,7 +233,7 @@ export const sourceLanguages: ISourceLanguage[] = [
 ];
 
 const variantDisplay: Map<Variant, string> = new Map([['non-det', 'Non-Det']]);
-export const sourceURLNames: Map<string, ISourceLanguage> = new Map([
+export const languageURLNames: Map<string, ISourceLanguage> = new Map([
   ['3_Non_Det', { chapter: 3, variant: 'non-det' }]
 ]);
 

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -223,6 +223,10 @@ export const sourceChapters = [1, 2, 3, 4, 4.3];
 export const sourceDisplayNames: Map<number, string> = new Map([[4.3, '3 Non-Det']]);
 export const sourceURLNames: Map<string, number> = new Map([['3_Non_Det', 4.3]]);
 
+export const styliseChapter = (chap: number) => {
+  return `Source \xa7${sourceDisplayNames.has(chap) ? sourceDisplayNames.get(chap) : chap}`;
+};
+
 const currentEnvironment = (): ApplicationEnvironment => {
   switch (process.env.NODE_ENV) {
     case 'development':

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -256,7 +256,12 @@ export const defaultEditorValue = '// Type your program in here!';
 export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): IWorkspaceState => ({
   autogradingResults: [],
   breakpoints: [],
-  context: createContext<WorkspaceLocation>(DEFAULT_SOURCE_CHAPTER, DEFAULT_SOURCE_VARIANT, [], workspaceLocation),
+  context: createContext<WorkspaceLocation>(
+    DEFAULT_SOURCE_CHAPTER,
+    DEFAULT_SOURCE_VARIANT,
+    [],
+    workspaceLocation
+  ),
   editorPrepend: '',
   editorSessionId: '',
   editorValue:

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -232,7 +232,7 @@ export const sourceLanguages: ISourceLanguage[] = [
   { chapter: 4, variant: 'default' }
 ];
 
-const variantDisplay: Map<Variant, string> = new Map([['default', ''], ['non-det', 'Non-Det']]);
+const variantDisplay: Map<Variant, string> = new Map([['non-det', 'Non-Det']]);
 export const sourceURLNames: Map<string, ISourceLanguage> = new Map([
   ['3_Non_Det', { chapter: 3, variant: 'non-det' }]
 ]);
@@ -240,7 +240,7 @@ export const sourceURLNames: Map<string, ISourceLanguage> = new Map([
 export const styliseChapter = (chap: number, variant?: Variant) => {
   let res = `Source \xa7${chap}`;
   if (variant && variantDisplay.has(variant)) {
-    res += variantDisplay.get(variant);
+    res += ' ' + variantDisplay.get(variant);
   }
   return res;
 };

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -237,9 +237,9 @@ export const languageURLNames: Map<string, ISourceLanguage> = new Map([
   ['3_Non_Det', { chapter: 3, variant: 'non-det' }]
 ]);
 
-export const styliseChapter = (chap: number, variant?: Variant) => {
+export const styliseChapter = (chap: number, variant: Variant = 'default') => {
   let res = `Source \xa7${chap}`;
-  if (variant && variantDisplay.has(variant)) {
+  if (variantDisplay.has(variant)) {
     res += ' ' + variantDisplay.get(variant);
   }
   return res;

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -1,5 +1,5 @@
 import { Context } from 'js-slang';
-import { SourceError } from 'js-slang/dist/types';
+import { SourceError, Variant } from 'js-slang/dist/types';
 
 import { WorkspaceLocation, WorkspaceLocations } from '../actions/workspaces';
 import { Grading, GradingOverview } from '../components/academy/grading/gradingShape';
@@ -219,12 +219,29 @@ export enum Role {
  * Defines what chapters are available for usage.
  * For external libraries, see externalLibraries.ts
  */
-export const sourceChapters = [1, 2, 3, 4];
-export const sourceVariants = ['non-det'];
+export interface ISourceLanguage {
+  chapter: number;
+  variant: Variant;
+}
+
+export const sourceLanguages: ISourceLanguage[] = [
+  { chapter: 1, variant: 'default' },
+  { chapter: 2, variant: 'default' },
+  { chapter: 3, variant: 'default' },
+  { chapter: 3, variant: 'non-det' },
+  { chapter: 4, variant: 'default' }
+];
+
+const variantDisplay: Map<Variant, string> = new Map([
+  ['default', ''],
+  ['non-det', 'Non-Det']
+]);
 export const sourceURLNames: Map<string, number> = new Map([['3_Non_Det', 4.3]]);
 
-export const styliseChapter = (chap: number) => {
-  return `Source \xa7${chap}`;
+export const styliseChapter = (chap: number, variant?: Variant) => {
+  
+  return `Source \xa7${chap}` + 
+    (!variant || variantDisplay[variant] === '' ? '' : ' ' + variantDisplay[variant]);
 };
 
 const currentEnvironment = (): ApplicationEnvironment => {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -219,7 +219,9 @@ export enum Role {
  * Defines what chapters are available for usage.
  * For external libraries, see externalLibraries.ts
  */
-export const sourceChapters = [1, 2, 3, 4];
+export const sourceChapters = [1, 2, 3, 4, 4.3];
+export const sourceDisplayNames: Map<number, string> = new Map([[4.3, '3 Non-Det']]);
+export const sourceURLNames: Map<string, number> = new Map([['3_Non_Det', 4.3]]);
 
 const currentEnvironment = (): ApplicationEnvironment => {
   switch (process.env.NODE_ENV) {

--- a/src/reducers/states.ts
+++ b/src/reducers/states.ts
@@ -264,9 +264,9 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): IW
   breakpoints: [],
   context: createContext<WorkspaceLocation>(
     DEFAULT_SOURCE_CHAPTER,
-    DEFAULT_SOURCE_VARIANT,
     [],
-    workspaceLocation
+    workspaceLocation,
+    DEFAULT_SOURCE_VARIANT,
   ),
   editorPrepend: '',
   editorSessionId: '',

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -267,7 +267,7 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
           ...state[workspaceLocation],
           context: createContext<WorkspaceLocation>(
             action.payload.library.chapter,
-            'default',
+            action.payload.library.variant,
             action.payload.library.external.symbols,
             workspaceLocation
           ),

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -267,9 +267,9 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
           ...state[workspaceLocation],
           context: createContext<WorkspaceLocation>(
             action.payload.library.chapter,
-            action.payload.library.variant,
             action.payload.library.external.symbols,
-            workspaceLocation
+            workspaceLocation,
+            action.payload.library.variant
           ),
           globals: action.payload.library.globals
         }

--- a/src/reducers/workspaces.ts
+++ b/src/reducers/workspaces.ts
@@ -267,6 +267,7 @@ export const reducer: Reducer<IWorkspaceManagerState> = (
           ...state[workspaceLocation],
           context: createContext<WorkspaceLocation>(
             action.payload.library.chapter,
+            'default',
             action.payload.library.external.symbols,
             workspaceLocation
           ),

--- a/src/sagas/__tests__/workspaces.ts
+++ b/src/sagas/__tests__/workspaces.ts
@@ -1,5 +1,5 @@
 import { Context, IOptions, Result, resume, runInContext } from 'js-slang';
-import { ErrorSeverity, ErrorType, Finished, SourceError } from 'js-slang/dist/types';
+import { ErrorSeverity, ErrorType, Finished, SourceError, Variant } from 'js-slang/dist/types';
 import { expectSaga } from 'redux-saga-test-plan';
 import { call } from 'redux-saga/effects';
 
@@ -51,6 +51,7 @@ describe('EVAL_EDITOR', () => {
     const editorPostpend = '42;';
     const execTime = 1000;
     const context = createContext();
+    const variant: Variant = 'default';
     const globals: Array<[string, any]> = [
       ['testNumber', 3.141592653589793],
       ['testObject', { a: 1, b: 2 }],
@@ -59,6 +60,7 @@ describe('EVAL_EDITOR', () => {
 
     const library = {
       chapter: context.chapter,
+      variant,
       external: {
         name: ExternalLibraryNames.NONE,
         symbols: context.externalSymbols
@@ -381,6 +383,7 @@ describe('CHAPTER_SELECT', () => {
     const newChapter = 3;
     const library: Library = {
       chapter: newChapter,
+      variant: 'default',
       external: {
         name: 'NONE' as ExternalLibraryName,
         symbols: context.externalSymbols
@@ -397,7 +400,7 @@ describe('CHAPTER_SELECT', () => {
       .call(showSuccessMessage, `Switched to Source \xa7${newChapter}`, 1000)
       .dispatch({
         type: actionTypes.CHAPTER_SELECT,
-        payload: { chapter: newChapter, workspaceLocation }
+        payload: { chapter: newChapter, variant: 'default', workspaceLocation }
       })
       .silentRun();
   });

--- a/src/sagas/__tests__/workspaces.ts
+++ b/src/sagas/__tests__/workspaces.ts
@@ -407,7 +407,7 @@ describe('CHAPTER_SELECT', () => {
 
   test('does not call beginClearContext, clearReplOutput and showSuccessMessage when oldChapter === newChapter and oldVariant === newVariant', () => {
     const newChapter = 4;
-    const newVariant: Variant = 'default'
+    const newVariant: Variant = 'default';
     const library: Library = {
       chapter: newChapter,
       variant: newVariant,

--- a/src/sagas/__tests__/workspaces.ts
+++ b/src/sagas/__tests__/workspaces.ts
@@ -405,10 +405,12 @@ describe('CHAPTER_SELECT', () => {
       .silentRun();
   });
 
-  test('does not call beginClearContext, clearReplOutput and showSuccessMessage when oldChapter === newChapter', () => {
+  test('does not call beginClearContext, clearReplOutput and showSuccessMessage when oldChapter === newChapter and oldVariant === newVariant', () => {
     const newChapter = 4;
+    const newVariant: Variant = 'default'
     const library: Library = {
       chapter: newChapter,
+      variant: newVariant,
       external: {
         name: 'NONE' as ExternalLibraryName,
         symbols: context.externalSymbols
@@ -425,7 +427,7 @@ describe('CHAPTER_SELECT', () => {
       .not.call(showSuccessMessage, `Switched to Source \xa7${newChapter}`, 1000)
       .dispatch({
         type: actionTypes.CHAPTER_SELECT,
-        payload: { chapter: newChapter, workspaceLocation }
+        payload: { chapter: newChapter, variant: newVariant, workspaceLocation }
       })
       .silentRun();
   });

--- a/src/sagas/playground.ts
+++ b/src/sagas/playground.ts
@@ -5,7 +5,9 @@ import { put, select, takeEvery } from 'redux-saga/effects';
 import * as actions from '../actions';
 import * as actionTypes from '../actions/actionTypes';
 import { ExternalLibraryName } from '../components/assessment/assessmentShape';
-import { defaultEditorValue, IState } from '../reducers/states';
+import { defaultEditorValue, ISourceLanguage, IState, languageURLNames } from '../reducers/states';
+
+import { Variant } from 'js-slang/dist/types';
 
 export default function* playgroundSaga(): SagaIterator {
   yield takeEvery(actionTypes.GENERATE_LZ_STRING, updateQueryString);
@@ -23,13 +25,26 @@ function* updateQueryString() {
   const chapter: number = yield select(
     (state: IState) => state.workspaces.playground.context.chapter
   );
+  const variant: Variant = yield select(
+    (state: IState) => state.workspaces.playground.context.variant
+  );
+
+  let languageUrlName: string = chapter.toString();
+  for (const name of languageURLNames.keys()) {
+    const language: ISourceLanguage = languageURLNames.get(name)!;
+    if (language.chapter === chapter && language.variant === variant) {
+      languageUrlName = name;
+      break;
+    }
+  }
+
   const external: ExternalLibraryName = yield select(
     (state: IState) => state.workspaces.playground.externalLibrary
   );
   const execTime: number = yield select((state: IState) => state.workspaces.playground.execTime);
   const newQueryString: string = qs.stringify({
     prgrm: compressToEncodedURIComponent(codeString),
-    chap: chapter,
+    chap: languageUrlName,
     ext: external,
     exec: execTime
   });

--- a/src/sagas/playground.ts
+++ b/src/sagas/playground.ts
@@ -5,7 +5,7 @@ import { put, select, takeEvery } from 'redux-saga/effects';
 import * as actions from '../actions';
 import * as actionTypes from '../actions/actionTypes';
 import { ExternalLibraryName } from '../components/assessment/assessmentShape';
-import { defaultEditorValue, ISourceLanguage, IState, languageURLNames } from '../reducers/states';
+import { defaultEditorValue, IState, urlName } from '../reducers/states';
 
 import { Variant } from 'js-slang/dist/types';
 
@@ -29,14 +29,7 @@ function* updateQueryString() {
     (state: IState) => state.workspaces.playground.context.variant
   );
 
-  let languageUrlName: string = chapter.toString();
-  for (const name of languageURLNames.keys()) {
-    const language: ISourceLanguage = languageURLNames.get(name)!;
-    if (language.chapter === chapter && language.variant === variant) {
-      languageUrlName = name;
-      break;
-    }
-  }
+  const languageUrlName: string = urlName(chapter, variant);
 
   const external: ExternalLibraryName = yield select(
     (state: IState) => state.workspaces.playground.externalLibrary

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -275,6 +275,7 @@ export default function* workspaceSaga(): SagaIterator {
     const oldChapter = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.chapter
     );
+    
     const symbols: string[] = yield select(
       (state: IState) =>
         (state.workspaces[workspaceLocation] as IWorkspaceState).context.externalSymbols

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -537,7 +537,7 @@ export function* evalCode(
     }
   }
 
-  function call_non_det(code: string) {
+  function call_non_det() {
     return code.trim() === TRY_AGAIN
       ? call(resume, lastNonDetResult)
       : code.includes(TRY_AGAIN) // defensive check: try-again should only be used on its own
@@ -555,7 +555,7 @@ export function* evalCode(
       actionType === actionTypes.DEBUG_RESUME
         ? call(resume, lastDebuggerResult)
         : isNonDet
-        ? call_non_det(code)
+        ? call_non_det()
         : call(runInContext, code, context, {
             scheduler: 'preemptive',
             originalMaxExecTime: execTime,

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -295,7 +295,7 @@ export default function* workspaceSaga(): SagaIterator {
       yield put(actions.beginClearContext(library, workspaceLocation));
       yield put(actions.clearReplOutput(workspaceLocation));
       yield put(actions.debuggerReset(workspaceLocation));
-      yield call(showSuccessMessage, `Switched to ${styliseChapter(newChapter)}`, 1000);
+      yield call(showSuccessMessage, `Switched to ${styliseChapter(newChapter, newVariant)}`, 1000);
     }
   });
 

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -14,7 +14,13 @@ import {
   TestcaseTypes
 } from '../components/assessment/assessmentShape';
 import { externalLibraries } from '../reducers/externalLibraries';
-import { IPlaygroundState, IState, IWorkspaceState, SideContentType } from '../reducers/states';
+import {
+  IPlaygroundState,
+  IState,
+  IWorkspaceState,
+  SideContentType,
+  styliseChapter
+} from '../reducers/states';
 import { showSuccessMessage, showWarningMessage } from '../utils/notification';
 import {
   getBlockExtraMethodsString,
@@ -278,7 +284,7 @@ export default function* workspaceSaga(): SagaIterator {
       yield put(actions.beginClearContext(library, workspaceLocation));
       yield put(actions.clearReplOutput(workspaceLocation));
       yield put(actions.debuggerReset(workspaceLocation));
-      yield call(showSuccessMessage, `Switched to Source \xa7${newChapter}`, 1000);
+      yield call(showSuccessMessage, `Switched to ${styliseChapter(newChapter)}`, 1000);
     }
   });
 

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -268,6 +268,9 @@ export default function* workspaceSaga(): SagaIterator {
   ) {
     const workspaceLocation = action.payload.workspaceLocation;
     const newChapter = action.payload.chapter;
+    const oldVariant = yield select(
+      (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.variant
+    );
     const newVariant = action.payload.variant;
     const oldChapter = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.chapter
@@ -279,7 +282,7 @@ export default function* workspaceSaga(): SagaIterator {
     const globals: Array<[string, any]> = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).globals
     );
-    if (newChapter !== oldChapter) {
+    if (newChapter !== oldChapter || newVariant !== oldVariant) {
       const library = {
         chapter: newChapter,
         variant: newVariant,

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -1,4 +1,5 @@
-import { Context, findDeclaration, interrupt, resume, runInContext } from 'js-slang';
+import { Context, findDeclaration, interrupt, Result, resume, runInContext } from 'js-slang';
+import { TRY_AGAIN } from 'js-slang/dist/constants';
 import { InterruptedError } from 'js-slang/dist/errors/errors';
 import { manualToggleDebugger } from 'js-slang/dist/stdlib/inspector';
 import { random } from 'lodash';
@@ -526,7 +527,7 @@ export function* evalCode(
     }
   }
 
-  const isNonDet: boolean = context.chapter === 4.3;
+  const isNonDet: boolean = context.variant === 'non-det';
   const { result, interrupted, paused } = yield race({
     result:
       actionType === actionTypes.DEBUG_RESUME
@@ -537,7 +538,6 @@ export function* evalCode(
           : code.includes(TRY_AGAIN) // defensive check: try-again should only be used on its own
           ? { status: 'error' }
           : call(runInContext, code, context, {
-              scheduler: 'non-det',
               executionMethod: 'interpreter',
               originalMaxExecTime: execTime,
               useSubst: substActiveAndCorrectChapter

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -2,6 +2,7 @@ import { Context, findDeclaration, interrupt, Result, resume, runInContext } fro
 import { TRY_AGAIN } from 'js-slang/dist/constants';
 import { InterruptedError } from 'js-slang/dist/errors/errors';
 import { manualToggleDebugger } from 'js-slang/dist/stdlib/inspector';
+import { Variant } from 'js-slang/dist/types';
 import { random } from 'lodash';
 import { SagaIterator } from 'redux-saga';
 import { call, delay, put, race, select, take, takeEvery } from 'redux-saga/effects';
@@ -69,8 +70,12 @@ export default function* workspaceSaga(): SagaIterator {
     const globals: Array<[string, any]> = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).globals
     );
+    const variant: Variant = yield select(
+      (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.variant
+    );
     const library = {
       chapter,
+      variant,
       external: {
         name: ExternalLibraryNames.NONE,
         symbols
@@ -263,6 +268,7 @@ export default function* workspaceSaga(): SagaIterator {
   ) {
     const workspaceLocation = action.payload.workspaceLocation;
     const newChapter = action.payload.chapter;
+    const newVariant = action.payload.variant;
     const oldChapter = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.chapter
     );
@@ -276,6 +282,7 @@ export default function* workspaceSaga(): SagaIterator {
     if (newChapter !== oldChapter) {
       const library = {
         chapter: newChapter,
+        variant: newVariant,
         external: {
           name: ExternalLibraryNames.NONE,
           symbols

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -275,7 +275,7 @@ export default function* workspaceSaga(): SagaIterator {
     const oldChapter = yield select(
       (state: IState) => (state.workspaces[workspaceLocation] as IWorkspaceState).context.chapter
     );
-    
+
     const symbols: string[] = yield select(
       (state: IState) =>
         (state.workspaces[workspaceLocation] as IWorkspaceState).context.externalSymbols

--- a/src/sagas/workspaces.ts
+++ b/src/sagas/workspaces.ts
@@ -546,7 +546,7 @@ export function* evalCode(
           executionMethod: 'interpreter',
           originalMaxExecTime: execTime,
           useSubst: substActiveAndCorrectChapter
-        })
+        });
   }
 
   const isNonDet: boolean = context.variant === 'non-det';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const USE_CHATKIT =
   process.env.REACT_APP_CHATKIT_INSTANCE_LOCATOR !== '';
 export const INSTANCE_LOCATOR = process.env.REACT_APP_CHATKIT_INSTANCE_LOCATOR;
 export const DEFAULT_SOURCE_CHAPTER = 4;
+export const DEFAULT_SOURCE_VARIANT = 'default';
 
 export enum LINKS {
   GITHUB_ISSUES = 'https://github.com/source-academy/cadet-frontend/issues',

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -123,7 +123,12 @@ export const externalBuiltIns = {
  * provides the original function with the required
  * externalBuiltIns, such as display and prompt.
  */
-export function createContext<T>(chapter: number, variant: Variant, externals: string[], externalContext: T) {
+export function createContext<T>(
+  chapter: number,
+  variant: Variant,
+  externals: string[],
+  externalContext: T
+) {
   return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
 }
 

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -129,7 +129,11 @@ export function createContext<T>(
   externals: string[],
   externalContext: T
 ) {
-  return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
+  if (chapter > 4) {
+    return createSlangContext<T>(chapter, 'non-det', externals, externalContext, externalBuiltIns);
+  } else {
+    return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
+  }
 }
 
 // Assumes that the grader doesn't need additional external libraries apart from the standard

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -1,6 +1,6 @@
 /* tslint:disable: ban-types*/
 import createSlangContext, { defineBuiltin, importBuiltins } from 'js-slang/dist/createContext';
-import { Context, CustomBuiltIns, Value } from 'js-slang/dist/types';
+import { Context, CustomBuiltIns, Value, Variant } from 'js-slang/dist/types';
 import { stringify } from 'js-slang/dist/utils/stringify';
 import { difference, keys } from 'lodash';
 import { handleConsoleLog } from '../actions';
@@ -123,8 +123,8 @@ export const externalBuiltIns = {
  * provides the original function with the required
  * externalBuiltIns, such as display and prompt.
  */
-export function createContext<T>(chapter: number, externals: string[], externalContext: T) {
-  return createSlangContext<T>(chapter, externals, externalContext, externalBuiltIns);
+export function createContext<T>(chapter: number, variant: Variant, externals: string[], externalContext: T) {
+  return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
 }
 
 // Assumes that the grader doesn't need additional external libraries apart from the standard

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -125,9 +125,9 @@ export const externalBuiltIns = {
  */
 export function createContext<T>(
   chapter: number,
-  variant: Variant | undefined,
   externals: string[],
-  externalContext: T
+  externalContext: T,
+  variant?: Variant
 ) {
   if (variant === undefined) {
     return createSlangContext<T>(chapter, 'default', externals, externalContext, externalBuiltIns);

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -125,12 +125,12 @@ export const externalBuiltIns = {
  */
 export function createContext<T>(
   chapter: number,
-  variant: Variant,
+  variant: Variant | undefined,
   externals: string[],
   externalContext: T
 ) {
-  if (chapter > 4) {
-    return createSlangContext<T>(chapter, 'non-det', externals, externalContext, externalBuiltIns);
+  if (variant === undefined) {
+    return createSlangContext<T>(chapter, 'default', externals, externalContext, externalBuiltIns);
   } else {
     return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
   }

--- a/src/utils/slangHelper.ts
+++ b/src/utils/slangHelper.ts
@@ -127,13 +127,9 @@ export function createContext<T>(
   chapter: number,
   externals: string[],
   externalContext: T,
-  variant?: Variant
+  variant: Variant = 'default'
 ) {
-  if (variant === undefined) {
-    return createSlangContext<T>(chapter, 'default', externals, externalContext, externalBuiltIns);
-  } else {
-    return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
-  }
+  return createSlangContext<T>(chapter, variant, externals, externalContext, externalBuiltIns);
 }
 
 // Assumes that the grader doesn't need additional external libraries apart from the standard


### PR DESCRIPTION
High level idea:
- Create an array `sourceVariants` that will hold all the possible variants (similar to  the existing `sourceChapters` array that holds the chapter numbers)
- Modify the logic used to generate the chapter dropdown, such that it includes the variants in `sourceVariants` when creating the dropdown.
- Pass in the variant to the handler function that reacts to the selection of a chapter.
Since some workspaces uses the same handler function, this step requires changes in many workspaces (not just `Playground`, but also `Grading`, `Sourcecast` and `Sourcereel`)

- Create variant as an optional property in the Library type

The variant has to be passed in the library object in two events:

- When the context is "reset" when a chapter is selected
- When the code is evaluated